### PR TITLE
Convert Cursor rules to OpenCode skills

### DIFF
--- a/.opencode/skills/payload-access-advanced/SKILL.md
+++ b/.opencode/skills/payload-access-advanced/SKILL.md
@@ -1,8 +1,6 @@
 ---
-title: Access Control - Advanced Patterns
-description: Context-aware, time-based, subscription-based access, factory functions, templates
-tags: [payload, access-control, security, advanced, performance]
-priority: high
+name: payload-access-advanced
+description: Advanced access control patterns including context-aware, time-based, subscription-based access, factory functions, and performance optimization
 ---
 
 # Advanced Access Control Patterns

--- a/.opencode/skills/payload-access/SKILL.md
+++ b/.opencode/skills/payload-access/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Access Control
-description: Collection, field, and global access control patterns
-tags: [payload, access-control, security, permissions, rbac]
+name: payload-access
+description: Collection, field, and global access control patterns for Payload CMS
 ---
 
 # Payload CMS Access Control

--- a/.opencode/skills/payload-adapters/SKILL.md
+++ b/.opencode/skills/payload-adapters/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Database Adapters & Transactions
-description: Database adapters, storage, email, and transaction patterns
-tags: [payload, database, mongodb, postgres, sqlite, transactions]
+name: payload-adapters
+description: Database adapters (MongoDB, Postgres, SQLite), storage adapters, email adapters, and transaction patterns
 ---
 
 # Payload CMS Adapters

--- a/.opencode/skills/payload-collections/SKILL.md
+++ b/.opencode/skills/payload-collections/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Collections
-description: Collection configurations and patterns
-tags: [payload, collections, auth, upload, drafts]
+name: payload-collections
+description: Collection configurations including basic collections, auth with RBAC, uploads, drafts, and globals
 ---
 
 # Payload CMS Collections

--- a/.opencode/skills/payload-components/SKILL.md
+++ b/.opencode/skills/payload-components/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: payload-components
+description: Custom React components for Payload Admin Panel including root, collection, global, and field components
+---
+
 # Custom Components in Payload CMS
 
 Custom Components allow you to fully customize the Admin Panel by swapping in your own React components. You can replace nearly every part of the interface or add entirely new functionality.

--- a/.opencode/skills/payload-endpoints/SKILL.md
+++ b/.opencode/skills/payload-endpoints/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Custom Endpoints
-description: Custom REST API endpoints with authentication and helpers
-tags: [payload, endpoints, api, routes, webhooks]
+name: payload-endpoints
+description: Custom REST API endpoints with authentication, route parameters, query handling, and error management
 ---
 
 # Payload Custom Endpoints

--- a/.opencode/skills/payload-field-guards/SKILL.md
+++ b/.opencode/skills/payload-field-guards/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Field Type Guards
-description: Runtime field type checking and safe type narrowing
-tags: [payload, typescript, type-guards, fields]
+name: payload-field-guards
+description: Runtime field type checking and safe type narrowing utilities for Payload CMS
 ---
 
 # Payload Field Type Guards

--- a/.opencode/skills/payload-fields/SKILL.md
+++ b/.opencode/skills/payload-fields/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Fields
-description: Field types, patterns, and configurations
-tags: [payload, fields, validation, conditional]
+name: payload-fields
+description: Field types, patterns, and configurations including text, richText, relationships, arrays, blocks, uploads, and validation
 ---
 
 # Payload CMS Fields

--- a/.opencode/skills/payload-hooks/SKILL.md
+++ b/.opencode/skills/payload-hooks/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Hooks
-description: Collection hooks, field hooks, and context patterns
-tags: [payload, hooks, lifecycle, context]
+name: payload-hooks
+description: Collection hooks, field hooks, context patterns, and lifecycle management for Payload CMS
 ---
 
 # Payload CMS Hooks

--- a/.opencode/skills/payload-overview/SKILL.md
+++ b/.opencode/skills/payload-overview/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Payload CMS Overview
-description: Core principles and quick reference for Payload CMS development
-tags: [payload, overview, quickstart]
+name: payload-overview
+description: Core principles, project structure, quick reference, and getting started for Payload CMS development
 ---
 
 # Payload CMS Development Rules

--- a/.opencode/skills/payload-plugins/SKILL.md
+++ b/.opencode/skills/payload-plugins/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Plugin Development
-description: Creating Payload CMS plugins with TypeScript patterns
-tags: [payload, plugins, architecture, patterns]
+name: payload-plugins
+description: Creating Payload CMS plugins with TypeScript patterns including field injection, hooks, endpoints, and configuration
 ---
 
 # Payload Plugin Development

--- a/.opencode/skills/payload-queries/SKILL.md
+++ b/.opencode/skills/payload-queries/SKILL.md
@@ -1,7 +1,6 @@
 ---
-title: Queries
-description: Local API, REST, and GraphQL query patterns
-tags: [payload, queries, local-api, rest, graphql]
+name: payload-queries
+description: Local API, query operators, AND/OR logic, nested properties, and performance optimization for Payload CMS
 ---
 
 # Payload CMS Queries

--- a/.opencode/skills/payload-security/SKILL.md
+++ b/.opencode/skills/payload-security/SKILL.md
@@ -1,8 +1,6 @@
 ---
-title: Critical Security Patterns
-description: The three most important security patterns in Payload CMS
-tags: [payload, security, critical, access-control, transactions, hooks]
-priority: high
+name: payload-security
+description: The three most critical security patterns in Payload CMS - Local API access control, transaction safety, and preventing infinite hook loops
 ---
 
 # CRITICAL SECURITY PATTERNS


### PR DESCRIPTION
Migrate .cursor/rules directory to .opencode/skills structure for better organization and integration with OpenCode CLI tooling.