### PR TITLE
Fix mobile scroll indicator position

### DIFF
--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -1,5 +1,7 @@
 @import 'tailwindcss';
 
+@source '../../../components/**/*.{js,ts,jsx,tsx}';
+
 @keyframes grain {
   0%,
   100% {

--- a/src/components/motion/ScrollProgress.tsx
+++ b/src/components/motion/ScrollProgress.tsx
@@ -12,7 +12,7 @@ export function ScrollProgress() {
 
   return (
     <motion.div
-      className="fixed left-6 top-0 bottom-0 w-[2px] bg-[#e8e4db] origin-top z-40"
+      className="fixed left-2 lg:left-6 top-0 bottom-0 w-[2px] bg-[#e8e4db] origin-top z-40"
       style={{ scaleY }}
     >
       <motion.div className="absolute inset-0 bg-[#c4a35a]" style={{ scaleY }} />


### PR DESCRIPTION
## Summary

- Moves scroll indicator from `left-6` to `left-2` (8px) on mobile devices
- Maintains `left-6` position on desktop to preserve original design
- Fixes alignment issue where scroll indicator visually interfered with content on mobile

## Problem

On mobile, the scroll indicator was positioned at `left-6` (24px), which aligned exactly with the content padding (`px-6`). This caused the indicator to sit at the text's edge, making elements hard to read and creating visual noise.

## Solution

Adjusted the scroll indicator to position closer to the screen edge on mobile (`left-2`, or 8px), creating clear separation from the content while keeping the design clean on desktop.