### PR TITLE
Adjust mobile content padding for scroll indicator balance

### DIFF
--- a/src/app/(frontend)/rich/page.tsx
+++ b/src/app/(frontend)/rich/page.tsx
@@ -121,7 +121,7 @@ export default function RichHomePage() {
 
       {/* Navigation */}
       <nav className="fixed top-0 left-0 right-0 z-50 mix-blend-difference">
-        <div className="flex justify-between items-center px-6 lg:px-12 py-6">
+        <div className="flex justify-between items-center pl-8 pr-6 lg:px-12 py-6">
           <MagneticButton
             href="#"
             className="font-serif text-xl tracking-tight text-white"
@@ -149,7 +149,7 @@ export default function RichHomePage() {
       </nav>
 
       {/* Hero Section */}
-      <section className="min-h-screen flex flex-col justify-center px-6 lg:px-12 pt-24 pb-16 relative">
+      <section className="min-h-screen flex flex-col justify-center pl-8 pr-6 lg:px-12 pt-24 pb-16 relative">
         <GrainOverlay opacity={0.02} />
         <MouseFollowHighlight />
 
@@ -200,7 +200,7 @@ export default function RichHomePage() {
       </section>
 
       {/* Featured Projects */}
-      <section id="projects" className="py-24 lg:py-32 px-6 lg:px-12">
+      <section id="projects" className="py-24 lg:py-32 pl-8 pr-6 lg:px-12">
         <div className="max-w-6xl mx-auto">
           <ScrollReveal className="flex items-baseline justify-between mb-16">
             <h2 className="font-serif text-4xl lg:text-5xl tracking-tight">Selected Work</h2>
@@ -339,7 +339,7 @@ export default function RichHomePage() {
       </section>
 
       {/* Credibility Bar */}
-      <section className="py-24 lg:py-32 px-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1]">
+      <section className="py-24 lg:py-32 pl-8 pr-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1]">
         <div className="max-w-6xl mx-auto">
           <ScrollReveal>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-16">
@@ -372,7 +372,7 @@ export default function RichHomePage() {
       </section>
 
       {/* Tech Stack */}
-      <section className="py-24 lg:py-32 px-6 lg:px-12">
+      <section className="py-24 lg:py-32 pl-8 pr-6 lg:px-12">
         <div className="max-w-6xl mx-auto">
           <ScrollReveal className="mb-16">
             <h2 className="font-serif text-4xl lg:text-5xl tracking-tight">Tech Stack</h2>
@@ -434,7 +434,7 @@ export default function RichHomePage() {
       </section>
 
       {/* Lab Section */}
-      <section className="py-24 lg:py-32 px-6 lg:px-12 bg-[#f0ece3]">
+      <section className="py-24 lg:py-32 pl-8 pr-6 lg:px-12 bg-[#f0ece3]">
         <div className="max-w-6xl mx-auto">
           <ScrollReveal className="flex items-baseline justify-between mb-12">
             <h2 className="font-serif text-4xl lg:text-5xl tracking-tight">Lab</h2>
@@ -497,7 +497,7 @@ export default function RichHomePage() {
       </section>
 
       {/* Contact / Footer */}
-      <footer className="py-24 lg:py-32 px-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1]">
+      <footer className="py-24 lg:py-32 pl-8 pr-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1]">
         <div className="max-w-6xl mx-auto">
           <ScrollReveal>
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 mb-16">

--- a/src/components/home/EducationSection.tsx
+++ b/src/components/home/EducationSection.tsx
@@ -25,7 +25,7 @@ export function EducationSection({ education }: EducationSectionProps) {
   const firstEducation = education[0]
 
   return (
-    <section className="py-24 lg:py-32 px-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1] border-t border-[#333]">
+    <section className="py-24 lg:py-32 pl-8 pr-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1] border-t border-[#333]">
       <div className="max-w-6xl mx-auto">
         <ScrollReveal delay={0.1}>
           <div>

--- a/src/components/home/ExperienceSection.tsx
+++ b/src/components/home/ExperienceSection.tsx
@@ -25,7 +25,7 @@ export function ExperienceSection({ experiences }: ExperienceSectionProps) {
   const firstExperience = experiences[0]
 
   return (
-    <section className="py-24 lg:py-32 px-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1]">
+    <section className="py-24 lg:py-32 pl-8 pr-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1]">
       <div className="max-w-6xl mx-auto">
         <ScrollReveal>
           <div>

--- a/src/components/home/FooterSection.tsx
+++ b/src/components/home/FooterSection.tsx
@@ -13,7 +13,7 @@ interface FooterSectionProps {
 
 export function FooterSection({ email, githubUrl, linkedinUrl }: FooterSectionProps) {
   return (
-    <footer className="py-24 lg:py-32 px-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1]">
+    <footer className="py-24 lg:py-32 pl-8 pr-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1]">
       <div className="max-w-6xl mx-auto">
         <ScrollReveal>
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 mb-16">

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -21,7 +21,7 @@ export function HeroSection({ hero, resumeUrl }: HeroSectionProps) {
   if (!hero) return null
 
   return (
-    <section className="min-h-screen flex flex-col justify-center px-6 lg:px-12 pt-24 pb-16 relative">
+    <section className="min-h-screen flex flex-col justify-center pl-8 pr-6 lg:px-12 pt-24 pb-16 relative">
       <ScrollProgress />
       <GrainOverlay opacity={0.02} />
 

--- a/src/components/home/LabSection.tsx
+++ b/src/components/home/LabSection.tsx
@@ -18,7 +18,7 @@ export function LabSection({ lab }: LabSectionProps) {
   if (!lab || lab.length === 0) return null
 
   return (
-    <section className="py-24 lg:py-32 px-6 lg:px-12 bg-[#f0ece3]">
+    <section className="py-24 lg:py-32 pl-8 pr-6 lg:px-12 bg-[#f0ece3]">
       <div className="max-w-6xl mx-auto">
         <ScrollReveal className="flex items-baseline justify-between mb-12">
           <h2 className="font-serif text-4xl lg:text-5xl tracking-tight">Lab</h2>

--- a/src/components/home/ProjectsSection.tsx
+++ b/src/components/home/ProjectsSection.tsx
@@ -11,7 +11,7 @@ export function ProjectsSection({ projects }: ProjectsSectionProps) {
   if (!projects || projects.length === 0) return null
 
   return (
-    <section id="projects" className="py-24 lg:py-32 px-6 lg:px-12">
+    <section id="projects" className="py-24 lg:py-32 pl-8 pr-6 lg:px-12">
       <div className="max-w-6xl mx-auto">
         <header className="flex items-baseline justify-between mb-16">
           <h2 className="font-serif text-4xl lg:text-5xl tracking-tight">Selected Work</h2>

--- a/src/components/home/TechStackSection.tsx
+++ b/src/components/home/TechStackSection.tsx
@@ -29,7 +29,7 @@ export function TechStackSection({ technologies }: TechStackSectionProps) {
   if (categories.length === 0) return null
 
   return (
-    <section className="py-24 lg:py-32 px-6 lg:px-12">
+    <section className="py-24 lg:py-32 pl-8 pr-6 lg:px-12">
       <div className="max-w-6xl mx-auto">
         <ScrollReveal className="mb-16">
           <h2 className="font-serif text-4xl lg:text-5xl tracking-tight">Tech Stack</h2>

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -12,7 +12,7 @@ interface NavigationProps {
 export function Navigation({ siteName = 'Hugo Hsi', githubUrl, linkedinUrl }: NavigationProps) {
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 mix-blend-difference">
-      <div className="flex justify-between items-center px-6 lg:px-12 py-6">
+      <div className="flex justify-between items-center pl-8 pr-6 lg:px-12 py-6">
         <MagneticButton
           href="#"
           className="font-serif text-xl tracking-tight text-white"


### PR DESCRIPTION
## Summary

- Changes mobile padding from symmetric `px-6` to asymmetric `pl-8 pr-6`
- Creates equal visual spacing: 24px from scroll indicator to content matches 24px from content to viewport edge

## Context

The scroll indicator is positioned at `left-2` (8px) on mobile. With the previous symmetric padding, the content started at 24px, leaving only 16px between the scroll indicator and content but 24px from content to edge.

## Solution

Adjusted left padding to `pl-8` (32px) while keeping right at `pr-6` (24px):
- Scroll indicator at 8px → content at 32px = **24px spacing**
- Content at 32px → viewport = **32px offset**
- Right content at 24px → viewport = **24px offset**

This establishes visual balance where the spacing between the scroll indicator and content equals the space from content to viewport edge.