### PR TITLE
Add mock homepage with hero section and typewriter improvements

### DIFF
--- a/scripts/update-homepage.ts
+++ b/scripts/update-homepage.ts
@@ -1,0 +1,60 @@
+import { getPayload } from 'payload'
+import config from '../src/payload.config.js'
+
+async function updateHomepage() {
+  const p = await getPayload({ config })
+
+  const updatedHero = {
+    firstName: 'Hugo',
+    lastName: 'Hsi',
+    role: 'FULL-STACK SOFTWARE ENGINEER',
+    tagline: 'Engineering products from design to database.',
+    intro: {
+      root: {
+        type: 'root',
+        format: '' as const,
+        indent: 0,
+        version: 1,
+        children: [
+          {
+            type: 'paragraph',
+            version: 1,
+            children: [
+              {
+                text: 'Software engineer specializing in React, Next.js, and Node.js. I bring hands-on agency experience from Praxis Loop, where I shipped client work ranging from complex headless CMS integrations to pixel-perfect Figma implementations.',
+                type: 'text',
+                version: 1,
+              },
+            ],
+          },
+        ],
+        direction: 'ltr' as const,
+      },
+    },
+    ctaPrimary: {
+      text: 'View my work',
+      link: '#projects',
+    },
+    ctaSecondary: {
+      text: 'Download resume',
+    },
+    quote:
+      "Beyond the keyboard, I'm a badminton coach, an avid gamer, and an active proponent of taking a proper break to do absolutely nothing.",
+  }
+
+  try {
+    const result = await p.updateGlobal({
+      slug: 'homepage',
+      data: {
+        hero: updatedHero,
+      },
+    })
+    console.log('Successfully updated homepage content!')
+  } catch (error) {
+    console.error('Error updating homepage:', error)
+  }
+
+  process.exit(0)
+}
+
+updateHomepage()

--- a/src/app/(frontend)/hero-mock/page.tsx
+++ b/src/app/(frontend)/hero-mock/page.tsx
@@ -1,0 +1,85 @@
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import { getHomepageData } from '@/lib/getHomepageData'
+import { Navigation } from '@/components/navigation/Navigation'
+import { HeroSectionMock } from '@/components/home/HeroSectionMock'
+import { ProjectsSection } from '@/components/home/ProjectsSection'
+import { ExperienceSection } from '@/components/home/ExperienceSection'
+import { EducationSection } from '@/components/home/EducationSection'
+import { TechStackSection } from '@/components/home/TechStackSection'
+import { LabSection } from '@/components/home/LabSection'
+import { FooterSection } from '@/components/home/FooterSection'
+
+export default async function HeroMockPage() {
+  const payload = await getPayload({ config })
+
+  const { homepage, featuredProjects, experiences, education, technologies, lab, contact } =
+    await getHomepageData(payload)
+
+  if (!homepage) {
+    return (
+      <div className="min-h-screen bg-[#f8f6f1] text-[#1a1a1a] flex items-center justify-center">
+        <p className="text-gray-500">Homepage content not found. Please configure in CMS.</p>
+      </div>
+    )
+  }
+
+  const resumeUrl =
+    typeof homepage.resume === 'object' && homepage.resume !== null ? homepage.resume.url : null
+
+  const mockedHero = {
+    firstName: homepage.hero?.firstName,
+    lastName: homepage.hero?.lastName,
+    tagline: 'Engineering products from design to database.',
+    intro: {
+      root: {
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            version: 1,
+            children: [
+              {
+                type: 'text',
+                version: 1,
+                text: 'Software engineer specializing in React, Next.js, and Node.js. I bring hands-on agency experience working directly with clients to deliver thoughtfully engineered applications.',
+                format: '',
+              },
+            ],
+            direction: 'ltr' as const,
+            format: '' as const,
+            indent: 0,
+          },
+        ],
+        direction: 'ltr' as const,
+        format: '' as const,
+        indent: 0,
+        version: 1,
+      },
+    },
+    ctaPrimary: homepage.hero?.ctaPrimary,
+    ctaSecondary: homepage.hero?.ctaSecondary,
+    quote:
+      "Beyond the keyboard, I'm a badminton coach, an avid gamer, and an active proponent of taking a proper break to do absolutely nothing.",
+  }
+
+  return (
+    <div className="min-h-screen bg-[#f8f6f1] text-[#1a1a1a] overflow-x-hidden">
+      <Navigation
+        githubUrl={contact?.github ?? undefined}
+        linkedinUrl={contact?.linkedin ?? undefined}
+      />
+      <HeroSectionMock hero={mockedHero} resumeUrl={resumeUrl} />
+      <ProjectsSection projects={featuredProjects} />
+      <ExperienceSection experiences={experiences} />
+      <EducationSection education={education} />
+      <TechStackSection technologies={technologies} />
+      <LabSection lab={lab} />
+      <FooterSection
+        email={contact?.email}
+        githubUrl={contact?.github}
+        linkedinUrl={contact?.linkedin}
+      />
+    </div>
+  )
+}

--- a/src/components/home/HeroSectionMock.tsx
+++ b/src/components/home/HeroSectionMock.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { motion } from 'motion/react'
+import { useState } from 'react'
+import { GrainOverlay } from '@/components/motion/GrainOverlay'
+import { ScrollProgress } from '@/components/motion/ScrollProgress'
+import { InkButton } from '@/components/motion/InkButton'
+import { TypewriterText } from '@/components/motion/TypewriterText'
+import { RichText } from '@/components/RichText'
+
+interface HeroSectionMockProps {
+  hero: {
+    role?: string | null
+    firstName?: string | null
+    lastName?: string | null
+    tagline?: string | null
+    intro?: {
+      root: {
+        type: string
+        children: {
+          type: string
+          version: number
+          [key: string]: unknown
+        }[]
+        direction: 'ltr' | 'rtl'
+        format: '' | 'left' | 'start' | 'center' | 'right' | 'end' | 'justify'
+        indent: number
+        version: number
+      }
+      [key: string]: unknown
+    } | null
+    ctaPrimary?: {
+      text?: string | null
+      link?: string | null
+    } | null
+    ctaSecondary?: {
+      text?: string | null
+    } | null
+    quote?: string | null
+  }
+  resumeUrl?: string | null
+}
+
+function QuoteMarks({ text }: { text: string }) {
+  return <span className="text-[#c4a35a]">{text}</span>
+}
+
+export function HeroSectionMock({ hero, resumeUrl }: HeroSectionMockProps) {
+  const [isTypingComplete, setIsTypingComplete] = useState(false)
+
+  if (!hero) return null
+
+  return (
+    <section className="min-h-screen flex flex-col justify-center pl-8 pr-6 lg:px-12 pt-24 pb-16 relative">
+      <ScrollProgress />
+      <GrainOverlay opacity={0.02} />
+
+      <div className="max-w-6xl mx-auto w-full relative z-20">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-12 lg:gap-8 items-end">
+          <div className="lg:col-span-8">
+            {hero.firstName && hero.lastName && (
+              <motion.p
+                className="font-sans text-sm uppercase tracking-[0.2em] text-[#8b8680] mb-6"
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.4, ease: [0.25, 0.46, 0.45, 0.94] }}
+              >
+                {hero.firstName} {hero.lastName}
+              </motion.p>
+            )}
+            {hero.tagline && (
+              <h1 className="font-serif text-4xl md:text-5xl lg:text-6xl text-[#1a1a1a] leading-[1.1] mb-8 max-w-2xl">
+                <TypewriterText
+                  text={hero.tagline}
+                  delay={0.3}
+                  speed={35}
+                  onComplete={() => setIsTypingComplete(true)}
+                />
+              </h1>
+            )}
+            {hero.intro && (
+              <motion.div
+                className="font-sans text-base text-[#5a5a5a] max-w-lg leading-relaxed mb-10"
+                initial={{ opacity: 0 }}
+                animate={isTypingComplete ? { opacity: 1 } : { opacity: 0 }}
+                transition={{ duration: 0.5, delay: isTypingComplete ? 0.1 : 0 }}
+              >
+                <RichText content={hero.intro} />
+              </motion.div>
+            )}
+            <div className="flex flex-wrap gap-4">
+              {hero.ctaPrimary?.text && hero.ctaPrimary?.link && (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={isTypingComplete ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+                  transition={{
+                    duration: 0.35,
+                    delay: isTypingComplete ? 0.22 : 0,
+                    ease: [0.25, 0.46, 0.45, 0.94],
+                  }}
+                >
+                  <InkButton href={hero.ctaPrimary.link}>{hero.ctaPrimary.text}</InkButton>
+                </motion.div>
+              )}
+              {hero.ctaSecondary?.text && (
+                <motion.div
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={isTypingComplete ? { opacity: 1, y: 0 } : { opacity: 0, y: 10 }}
+                  transition={{
+                    duration: 0.35,
+                    delay: isTypingComplete ? 0.37 : 0,
+                    ease: [0.25, 0.46, 0.45, 0.94],
+                  }}
+                >
+                  <InkButton href={resumeUrl || '#'} variant="outline">
+                    {hero.ctaSecondary.text}
+                  </InkButton>
+                </motion.div>
+              )}
+            </div>
+          </div>
+          <div className="lg:col-span-4 lg:text-right">
+            {hero.quote && (
+              <motion.p
+                className="font-serif text-sm text-[#8b8680] italic leading-relaxed"
+                initial={{ opacity: 0, x: 20 }}
+                animate={isTypingComplete ? { opacity: 1, x: 0 } : { opacity: 0, x: 20 }}
+                transition={{
+                  duration: 0.45,
+                  delay: isTypingComplete ? 0.52 : 0,
+                  ease: [0.25, 0.46, 0.45, 0.94],
+                }}
+              >
+                <QuoteMarks text="&ldquo;" />
+                {hero.quote}
+                <QuoteMarks text="&rdquo;" />
+              </motion.p>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/motion/TypewriterText.tsx
+++ b/src/components/motion/TypewriterText.tsx
@@ -8,6 +8,7 @@ interface TypewriterTextProps {
   className?: string
   delay?: number
   speed?: number
+  onComplete?: () => void
 }
 
 export function TypewriterText({
@@ -15,6 +16,7 @@ export function TypewriterText({
   className = '',
   delay = 0,
   speed = 40,
+  onComplete,
 }: TypewriterTextProps) {
   const [displayedText, setDisplayedText] = useState('')
   const [showCursor, setShowCursor] = useState(true)
@@ -34,6 +36,7 @@ export function TypewriterText({
           index++
         } else {
           clearInterval(interval)
+          onComplete?.()
         }
       }, speed)
 
@@ -41,7 +44,7 @@ export function TypewriterText({
     }, delay * 1000)
 
     return () => clearTimeout(startTimeout)
-  }, [isInView, text, delay, speed])
+  }, [isInView, text, delay, speed, onComplete])
 
   // Blink cursor
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Added `onComplete` callback to `TypewriterText` component for sequencing animations
- Created `HeroSectionMock` component with staggered reveal animations synchronized to typewriter completion
- Added hero-mock page route at `/hero-mock` for previewing the hero section
- Added `update-homepage.ts` script for content management

## Changes
- Modified `src/components/motion/TypewriterText.tsx` to support completion callbacks
- Added `src/components/home/HeroSectionMock.tsx` with delayed animations
- Added `src/app/(frontend)/hero-mock/page.tsx` as preview route
- Added `scripts/update-homepage.ts` utility script

This adds a mock hero section that sequences typewriter animation with reveal of intro, CTAs, and quote.