### PR TITLE
Simplify Projects collection schema

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -133,7 +133,6 @@ async function seed() {
       title: 'National Medal of Honor Museum',
       excerpt:
         'Complete CMS migration from WordPress to Prismic. Migrated content architecture, rebuilt component library, and maintained SEO rankings throughout transition.',
-      featured: true,
       context: 'work' as const,
       company: 'Praxis Loop',
       order: 1,
@@ -142,7 +141,6 @@ async function seed() {
       title: '1st Avenue Advisors',
       excerpt:
         'Client-facing pages with pixel-perfect Figma-to-code implementation. Built working contact forms, dynamic content sections, and responsive layouts.',
-      featured: true,
       context: 'work' as const,
       company: 'Praxis Loop',
       order: 2,
@@ -151,7 +149,6 @@ async function seed() {
       title: 'Content API Platform',
       excerpt:
         'Full-stack API service with authentication, rate limiting, and webhook support. Demonstrates backend architecture and database design beyond frontend work.',
-      featured: true,
       context: 'personal' as const,
       order: 3,
     },

--- a/src/collections/Projects.ts
+++ b/src/collections/Projects.ts
@@ -4,7 +4,7 @@ export const Projects: CollectionConfig = {
   slug: 'projects',
   admin: {
     useAsTitle: 'title',
-    defaultColumns: ['featured', 'order'],
+    defaultColumns: ['order'],
     listSearchableFields: ['title', 'excerpt'],
   },
   fields: [
@@ -33,13 +33,7 @@ export const Projects: CollectionConfig = {
         description: 'URL to the live project/demo',
       },
     },
-    {
-      name: 'sourceUrl',
-      type: 'text',
-      admin: {
-        description: 'URL to source code (GitHub, GitLab, etc.)',
-      },
-    },
+
     {
       name: 'technologies',
       type: 'relationship',
@@ -52,8 +46,6 @@ export const Projects: CollectionConfig = {
       options: [
         { label: 'Personal Project', value: 'personal' },
         { label: 'Work Project', value: 'work' },
-        { label: 'Learning Exercise', value: 'learning' },
-        { label: 'Open Source Contribution', value: 'opensource' },
       ],
       admin: {
         description:
@@ -68,14 +60,7 @@ export const Projects: CollectionConfig = {
         condition: (data) => data?.context === 'work',
       },
     },
-    {
-      name: 'featured',
-      type: 'checkbox',
-      defaultValue: false,
-      admin: {
-        description: 'Featured projects appear on the homepage and get priority placement',
-      },
-    },
+
     {
       name: 'order',
       type: 'number',

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -14,7 +14,6 @@ interface ProjectCardProps {
     context?: string
     company?: string
     liveUrl?: string | null
-    sourceUrl?: string | null
   }
 }
 
@@ -62,7 +61,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
 
   return (
     <article className="group">
-      <a href={project.liveUrl || project.sourceUrl || '#'} className="block">
+      <a href={project.liveUrl || '#'} className="block">
         <StaggerContainer className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8 items-start">
           <StaggerItem className="lg:col-span-7">
             <ImageLift className={`${featuredBg} ring-1 ring-black/[0.08]`}>

--- a/src/lib/getHomepageData.ts
+++ b/src/lib/getHomepageData.ts
@@ -8,9 +8,6 @@ export async function getHomepageData(payload: Payload) {
 
       payload.find({
         collection: 'projects',
-        where: {
-          featured: { equals: true },
-        },
         sort: 'order',
         limit: 3,
         depth: 2,

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -242,23 +242,15 @@ export interface Project {
    * URL to the live project/demo
    */
   liveUrl?: string | null;
-  /**
-   * URL to source code (GitHub, GitLab, etc.)
-   */
-  sourceUrl?: string | null;
   technologies?: (number | Technology)[] | null;
   /**
    * Tells recruiters where this project came from without them navigating to Experience
    */
-  context?: ('personal' | 'work' | 'learning' | 'opensource') | null;
+  context?: ('personal' | 'work') | null;
   /**
    * If work project, which company? (shown alongside context)
    */
   company?: string | null;
-  /**
-   * Featured projects appear on the homepage and get priority placement
-   */
-  featured?: boolean | null;
   /**
    * Display order (lower numbers appear first)
    */
@@ -473,11 +465,9 @@ export interface ProjectsSelect<T extends boolean = true> {
   excerpt?: T;
   featuredImage?: T;
   liveUrl?: T;
-  sourceUrl?: T;
   technologies?: T;
   context?: T;
   company?: T;
-  featured?: T;
   order?: T;
   updatedAt?: T;
   createdAt?: T;


### PR DESCRIPTION
## Summary
- Removed `featured` checkbox field from Projects collection (no longer needed - all projects are now featured with max 5 limit)
- Removed `sourceUrl` text field from Projects collection
- Removed `learning` and `opensource` options from context selector (now only `personal` and `work`)
- Updated homepage data query to remove `featured: { equals: true }` filter
- Cleaned up ProjectCard component to remove stale `sourceUrl` references
- Updated seed data to remove `featured: true` properties