### PR TITLE
Fix: Font configuration and typewriter caret height

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -1,5 +1,19 @@
+import { Outfit, Forum } from 'next/font/google'
 import React from 'react'
 import './styles.css'
+
+const sans = Outfit({
+  subsets: ['latin'],
+  variable: '--font-sans',
+  display: 'swap',
+})
+
+const serif = Forum({
+  subsets: ['latin'],
+  variable: '--font-serif',
+  display: 'swap',
+  weight: ['400'],
+})
 
 export const metadata = {
   description: "Hugo Hsi - Full-stack developer with a designer's eye",
@@ -10,8 +24,8 @@ export default async function RootLayout(props: { children: React.ReactNode }) {
   const { children } = props
 
   return (
-    <html lang="en">
-      <body className="antialiased">{children}</body>
+    <html lang="en" className={`${sans.variable} ${serif.variable}`}>
+      <body className="font-sans antialiased">{children}</body>
     </html>
   )
 }

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -1,5 +1,10 @@
 @import 'tailwindcss';
 
+@theme {
+  --font-sans: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+  --font-serif: var(--font-serif), ui-serif, Georgia, serif;
+}
+
 @source '../../../components/**/*.{js,ts,jsx,tsx}';
 
 @keyframes grain {

--- a/src/components/motion/TypewriterText.tsx
+++ b/src/components/motion/TypewriterText.tsx
@@ -58,7 +58,7 @@ export function TypewriterText({
     <span ref={ref} className={className}>
       {displayedText}
       <span
-        className={`inline-block w-[2px] h-[1em] bg-current ml-1 transition-opacity duration-100 ${showCursor ? 'opacity-100' : 'opacity-0'}`}
+        className={`inline-block w-[2px] h-[1cap] bg-current ml-1 vertical-align-baseline transition-opacity duration-100 ${showCursor ? 'opacity-100' : 'opacity-0'}`}
       />
     </span>
   )


### PR DESCRIPTION
## Summary
- **Added font configuration**: Import Outfit (sans-serif) and Forum (serif) using `next/font/google`
- **Fixed line spacing issue**: Changed typewriter caret height from `1em` to `1cap` to match font cap-height
- **Added vertical alignment**: Applied `vertical-align-baseline` to prevent line-height distortion

## Problem
The fonts were falling back to system defaults (sans-serif and serif) because no custom fonts were loaded. Additionally, the typewriter cursor was causing inconsistent line spacing in multi-line headings because it used `h-[1em]` which exceeded the font's cap-height.

## Changes
- `src/app/(frontend)/layout.tsx`: Import and configure Outfit and Forum fonts
- `src/app/(frontend)/styles.css`: Add `@theme` block for Tailwind font mapping
- `src/components/motion/TypewriterText.tsx`: Fix caret height to `h-[1cap]` with `vertical-align-baseline`
