### PR TITLE
Fix: Match top and bottom overscroll color to footer on iOS

### DIFF
--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -20,6 +20,12 @@ export const metadata = {
   title: 'Hugo Hsi | Portfolio',
 }
 
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  viewportFit: 'cover',
+}
+
 export default async function RootLayout(props: { children: React.ReactNode }) {
   const { children } = props
 

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -28,17 +28,19 @@ export default async function HomePage() {
     typeof homepage.resume === 'object' && homepage.resume !== null ? homepage.resume.url : null
 
   return (
-    <div className="min-h-screen bg-[#f8f6f1] text-[#1a1a1a] overflow-x-hidden">
-      <Navigation
-        githubUrl={contact?.github ?? undefined}
-        linkedinUrl={contact?.linkedin ?? undefined}
-      />
-      <HeroSection hero={homepage.hero} resumeUrl={resumeUrl} />
-      <ProjectsSection projects={featuredProjects} />
-      <ExperienceSection experiences={experiences} />
-      <EducationSection education={education} />
-      <TechStackSection technologies={technologies} />
-      <LabSection lab={lab} />
+    <div className="min-h-screen overflow-x-hidden">
+      <div className="bg-[#f8f6f1] text-[#1a1a1a]">
+        <Navigation
+          githubUrl={contact?.github ?? undefined}
+          linkedinUrl={contact?.linkedin ?? undefined}
+        />
+        <HeroSection hero={homepage.hero} resumeUrl={resumeUrl} />
+        <ProjectsSection projects={featuredProjects} />
+        <ExperienceSection experiences={experiences} />
+        <EducationSection education={education} />
+        <TechStackSection technologies={technologies} />
+        <LabSection lab={lab} />
+      </div>
       <FooterSection
         email={contact?.email}
         githubUrl={contact?.github}

--- a/src/app/(frontend)/styles.css
+++ b/src/app/(frontend)/styles.css
@@ -7,6 +7,22 @@
 
 @source '../../../components/**/*.{js,ts,jsx,tsx}';
 
+@layer base {
+  html {
+    background-color: rgb(26 26 26);
+  }
+  body {
+    background-color: rgb(26 26 26);
+    min-height: 100dvh;
+    padding-top: env(safe-area-inset-top);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
+  footer {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+}
+
 @keyframes grain {
   0%,
   100% {


### PR DESCRIPTION
## Summary
- Set html and body background to dark (#1a1a1a) matching footer color
- Wrap content sections in a light background div for visual separation
- Add viewport-fit=cover meta tag for edge-to-edge rendering on iOS
- Keep footer padding-bottom for safe area inset handling

This ensures consistent dark overscroll color on iOS Safari with Liquid Glass, where toolbar/overscroll colors are derived from body background color.