### PR TITLE
Add scroll-based name reveal in header

### DIFF
--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -33,6 +33,7 @@ export function HeroSection({ hero, resumeUrl }: HeroSectionProps) {
           <div className="lg:col-span-8">
             {hero.firstName && hero.lastName && (
               <motion.p
+                id="hero-eyebrow"
                 className="font-sans text-sm uppercase tracking-[0.2em] text-[#8b8680] mb-6"
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -2,6 +2,8 @@
 
 import { GithubLogo, LinkedinLogo } from '@phosphor-icons/react'
 import { MagneticButton } from '@/components/motion/MouseEffects'
+import { motion } from 'motion/react'
+import { useState, useEffect } from 'react'
 
 interface NavigationProps {
   siteName?: string
@@ -10,6 +12,26 @@ interface NavigationProps {
 }
 
 export function Navigation({ siteName = 'Hugo Hsi', githubUrl, linkedinUrl }: NavigationProps) {
+  const [showName, setShowName] = useState(false)
+
+  useEffect(() => {
+    const eyebrow = document.getElementById('hero-eyebrow')
+    if (!eyebrow) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setShowName(!entry.isIntersecting)
+      },
+      {
+        threshold: 0,
+        rootMargin: '0px 0px 0px 0px',
+      },
+    )
+
+    observer.observe(eyebrow)
+    return () => observer.disconnect()
+  }, [])
+
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 mix-blend-difference">
       <div className="flex justify-between items-center pl-8 pr-6 lg:px-12 py-6">
@@ -18,7 +40,13 @@ export function Navigation({ siteName = 'Hugo Hsi', githubUrl, linkedinUrl }: Na
           className="font-serif text-xl tracking-tight text-white"
           intensity={0.2}
         >
-          {siteName}
+          <motion.span
+            initial={{ opacity: 0, y: -5 }}
+            animate={{ opacity: showName ? 1 : 0, y: showName ? 0 : -5 }}
+            transition={{ duration: 0.5, ease: 'easeOut' }}
+          >
+            {siteName}
+          </motion.span>
         </MagneticButton>
         <div className="flex items-center gap-6">
           {githubUrl && (


### PR DESCRIPTION
## Summary
- Prevents duplicate "Hugo Hsi" name appearing simultaneously in hero and header above the fold
- Hides header name by default, fades in when hero eyebrow text scrolls off-screen
- Uses IntersectionObserver for precise cross-browser detection

## Changes
- Added `id="hero-eyebrow"` to hero eyebrow element for observation
- Replaced simple scroll threshold with `IntersectionObserver` for accurate viewport exit detection
- Added Framer Motion animation for smooth fade-in and fade-out transitions
- Behavior: Header name hidden at load, appears when eyebrow exits viewport, disappears when scrolling back up

## Files Modified
- `src/components/home/HeroSection.tsx` - Added ID to eyebrow element
- `src/components/navigation/Navigation.tsx` - Implemented IntersectionObserver and fade animation

## Testing
- Desktop: Perfect timing, eyebrow appears to "hand off" to header name
- Mobile: Fade-in works correctly, timing acceptable (covered by clock/notch in practice)
- Scroll up/down bidirectional behavior verified