### PR TITLE
Prevent typographic orphans in hero and experience sections

### DIFF
--- a/src/components/home/ExperienceSection.tsx
+++ b/src/components/home/ExperienceSection.tsx
@@ -38,7 +38,7 @@ export function ExperienceSection({ experiences }: ExperienceSectionProps) {
               {formatDate(firstExperience.startDate)} — {formatDate(firstExperience.endDate)}
             </p>
             {firstExperience.description && typeof firstExperience.description === 'string' && (
-              <p className="font-sans text-[#b8b4ab] leading-relaxed">
+              <p className="font-sans text-[#b8b4ab] leading-relaxed text-pretty">
                 {firstExperience.description}
               </p>
             )}

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -54,7 +54,7 @@ export function HeroSection({ hero, resumeUrl }: HeroSectionProps) {
             )}
             {hero.intro && (
               <motion.div
-                className="font-sans text-base text-[#5a5a5a] max-w-lg leading-relaxed mb-10"
+                className="font-sans text-base text-[#5a5a5a] max-w-lg leading-relaxed mb-10 text-pretty"
                 initial={{ opacity: 0 }}
                 animate={isTypingComplete ? { opacity: 1 } : { opacity: 0 }}
                 transition={{ duration: 0.5, delay: isTypingComplete ? 0.1 : 0 }}
@@ -96,7 +96,7 @@ export function HeroSection({ hero, resumeUrl }: HeroSectionProps) {
           <div className="lg:col-span-4 lg:text-right">
             {hero.quote && (
               <motion.p
-                className="font-serif text-sm text-[#8b8680] italic leading-relaxed"
+                className="font-serif text-sm text-[#8b8680] italic leading-relaxed text-pretty"
                 initial={{ opacity: 0, x: 20 }}
                 animate={isTypingComplete ? { opacity: 1, x: 0 } : { opacity: 0, x: 20 }}
                 transition={{


### PR DESCRIPTION
## Summary
- Added `text-pretty` utility from Tailwind CSS v4 to prevent orphans (single words on last line)
- Applied to hero intro, hero quote, and experience section descriptions
- Hero tagline excluded from `text-balance` due to layout shifts during typewriter animation

## Details
**Changes:**
- `src/components/home/HeroSection.tsx`: Added `text-pretty` to intro and quote elements
- `src/components/home/ExperienceSection.tsx`: Added `text-pretty` to description

**Rationale:**
The original issue was random orphans appearing in the hero section text, especially the quote. The `text-pretty` utility helps prevent this by preferring better text wrapping.

**Excluded:**
- Hero tagline (`h1`): Not using `text-balance` because the typewriter animation causes constant layout recalculation as each character is typed. Even applying it conditionally after typing completes causes noticeable text shifts that look jarring.

## Testing
- Verified orphans are prevented in static text sections (intro, quote, experience)
- Confirmed no layout shift during typewriter animation on tagline
- Experience section orphan prevention working as expected