### PR TITLE
Change homepage intro field from rich text to textarea

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -310,28 +310,8 @@ async function seed() {
       firstName: 'Hugo',
       lastName: 'Hsi',
       tagline: 'Engineering products from design to database.',
-      intro: {
-        root: {
-          type: 'root',
-          format: '' as const,
-          indent: 0,
-          version: 1,
-          children: [
-            {
-              type: 'paragraph',
-              version: 1,
-              children: [
-                {
-                  text: 'Software engineer specializing in React, Next.js, and Node.js. I bring hands-on agency experience working directly with clients to deliver thoughtfully engineered applications.',
-                  type: 'text',
-                  version: 1,
-                },
-              ],
-            },
-          ],
-          direction: 'ltr' as const,
-        },
-      },
+      intro:
+        'Software engineer specializing in React, Next.js, and Node.js. I bring hands-on agency experience working directly with clients to deliver thoughtfully engineered applications.',
       ctaPrimary: {
         text: 'View my work',
         link: '#projects',

--- a/scripts/update-homepage.ts
+++ b/scripts/update-homepage.ts
@@ -11,28 +11,8 @@ async function updateHomepage() {
     firstName: 'Hugo',
     lastName: 'Hsi',
     tagline: 'Engineering products from design to database.',
-    intro: {
-      root: {
-        type: 'root',
-        format: '' as const,
-        indent: 0,
-        version: 1,
-        children: [
-          {
-            type: 'paragraph',
-            version: 1,
-            children: [
-              {
-                text: 'Software engineer specializing in React, Next.js, and Node.js. I bring hands-on agency experience working directly with clients to deliver thoughtfully engineered applications.',
-                type: 'text',
-                version: 1,
-              },
-            ],
-          },
-        ],
-        direction: 'ltr' as const,
-      },
-    },
+    intro:
+      'Software engineer specializing in React, Next.js, and Node.js. I bring hands-on agency experience working directly with clients to deliver thoughtfully engineered applications.',
     ctaPrimary: {
       text: 'View my work',
       link: '#projects',

--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,53 +1,7 @@
-import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
-import { InlineToolbarFeatureClient as InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { HorizontalRuleFeatureClient as HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UploadFeatureClient as UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { BlockquoteFeatureClient as BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { RelationshipFeatureClient as RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { LinkFeatureClient as LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { ChecklistFeatureClient as ChecklistFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { OrderedListFeatureClient as OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UnorderedListFeatureClient as UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { IndentFeatureClient as IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { AlignFeatureClient as AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { HeadingFeatureClient as HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { ParagraphFeatureClient as ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { InlineCodeFeatureClient as InlineCodeFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { SuperscriptFeatureClient as SuperscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { SubscriptFeatureClient as SubscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
-import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from '@payloadcms/richtext-lexical/client'
 import { VercelBlobClientUploadHandler as VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e } from '@payloadcms/storage-vercel-blob/client'
 import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } from '@payloadcms/next/rsc'
 
 export const importMap = {
-  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,
-  "@payloadcms/richtext-lexical/client#InlineToolbarFeatureClient": InlineToolbarFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#HorizontalRuleFeatureClient": HorizontalRuleFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UploadFeatureClient": UploadFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#BlockquoteFeatureClient": BlockquoteFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#RelationshipFeatureClient": RelationshipFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#LinkFeatureClient": LinkFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#ChecklistFeatureClient": ChecklistFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#OrderedListFeatureClient": OrderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UnorderedListFeatureClient": UnorderedListFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#IndentFeatureClient": IndentFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#AlignFeatureClient": AlignFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#HeadingFeatureClient": HeadingFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#ParagraphFeatureClient": ParagraphFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#InlineCodeFeatureClient": InlineCodeFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#SuperscriptFeatureClient": SuperscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#SubscriptFeatureClient": SubscriptFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#StrikethroughFeatureClient": StrikethroughFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#UnderlineFeatureClient": UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#BoldFeatureClient": BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@payloadcms/richtext-lexical/client#ItalicFeatureClient": ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/storage-vercel-blob/client#VercelBlobClientUploadHandler": VercelBlobClientUploadHandler_16c82c5e25f430251a3e3ba57219ff4e,
   "@payloadcms/next/rsc#CollectionCards": CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1
 }

--- a/src/components/home/HeroSection.tsx
+++ b/src/components/home/HeroSection.tsx
@@ -7,7 +7,6 @@ import { TypewriterText } from '@/components/motion/TypewriterText'
 import { InkButton } from '@/components/motion/InkButton'
 import { GrainOverlay } from '@/components/motion/GrainOverlay'
 import { ScrollProgress } from '@/components/motion/ScrollProgress'
-import { RichText } from '@/components/RichText'
 
 interface HeroSectionProps {
   hero: Homepage['hero']
@@ -53,14 +52,14 @@ export function HeroSection({ hero, resumeUrl }: HeroSectionProps) {
               </h1>
             )}
             {hero.intro && (
-              <motion.div
+              <motion.p
                 className="font-sans text-base text-[#5a5a5a] max-w-lg leading-relaxed mb-10 text-pretty"
                 initial={{ opacity: 0 }}
                 animate={isTypingComplete ? { opacity: 1 } : { opacity: 0 }}
                 transition={{ duration: 0.5, delay: isTypingComplete ? 0.1 : 0 }}
               >
-                <RichText content={hero.intro} />
-              </motion.div>
+                {hero.intro}
+              </motion.p>
             )}
             <div className="flex flex-wrap gap-4">
               {hero.ctaPrimary?.text && hero.ctaPrimary?.link && (

--- a/src/globals/Homepage.ts
+++ b/src/globals/Homepage.ts
@@ -34,7 +34,7 @@ export const Homepage: GlobalConfig = {
         },
         {
           name: 'intro',
-          type: 'richText',
+          type: 'textarea',
           admin: {
             description: "Bio paragraph. Keep it short - recruiters scan, they don't read.",
           },

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -548,21 +548,7 @@ export interface Homepage {
     /**
      * Bio paragraph. Keep it short - recruiters scan, they don't read.
      */
-    intro?: {
-      root: {
-        type: string;
-        children: {
-          type: any;
-          version: number;
-          [k: string]: unknown;
-        }[];
-        direction: ('ltr' | 'rtl') | null;
-        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
-        indent: number;
-        version: number;
-      };
-      [k: string]: unknown;
-    } | null;
+    intro?: string | null;
     ctaPrimary: {
       /**
        * Primary CTA button text


### PR DESCRIPTION
## Summary

Simplifies the intro field in the Homepage global from rich text to a regular textarea. The intro field doesn't need rich text formatting, and this removes unnecessary complexity.

## Changes

- **Homepage.ts**: Change intro field type from `richText` to `textarea`
- **HeroSection.tsx**: 
  - Remove unused `RichText` component import
  - Replace `<RichText content={hero.intro} />` with plain `{hero.intro}` text rendering
  - Change container from `div` to `p` for proper semantics
- **Seed scripts**: Update intro format from rich text JSON object to plain string
- **Regenerate payload types**: Updated type for intro field from complex object to `string | null`

## Files Changed

- `src/globals/Homepage.ts`
- `src/components/home/HeroSection.tsx`
- `src/payload-types.ts`
- `scripts/seed.ts`
- `scripts/update-homepage.ts`
- `src/app/(payload)/admin/importMap.js`