### PR TITLE
Remove unused lucide-react dependency and engine restrictions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "cross-env": "^7.0.3",
     "dotenv": "16.4.7",
     "graphql": "^16.8.1",
-    "lucide-react": "^0.577.0",
     "motion": "^12.36.0",
     "next": "15.4.11",
     "payload": "3.79.0",
@@ -55,10 +54,6 @@
     "typescript": "5.7.3",
     "vite-tsconfig-paths": "6.0.5",
     "vitest": "4.0.18"
-  },
-  "engines": {
-    "node": "^18.20.2 || ^20.9.0",
-    "pnpm": "^9 || ^10"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       graphql:
         specifier: ^16.8.1
         version: 16.13.1
-      lucide-react:
-        specifier: ^0.577.0
-        version: 0.577.0(react@19.2.1)
       motion:
         specifier: ^12.36.0
         version: 12.36.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -3319,11 +3316,6 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
-
-  lucide-react@0.577.0:
-    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
-    peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -7828,10 +7820,6 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
-
-  lucide-react@0.577.0(react@19.2.1):
-    dependencies:
-      react: 19.2.1
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## Summary
- Removed unused `lucide-react` dependency (package was installed but not imported anywhere)
- Removed `engines` section from package.json to allow project to run on Node LTS versions without warnings
- Updated pnpm-lock.yaml to reflect removed dependency

This resolves pnpm warnings about unsupported engine requirements when using Node.js v24 LTS.