### PR TITLE
Add timeline-style display for Education and Experience sections

### DIFF
--- a/src/collections/Experience.ts
+++ b/src/collections/Experience.ts
@@ -21,22 +21,25 @@ export const Experience: CollectionConfig = {
       name: 'startDate',
       type: 'date',
       required: true,
+      admin: {
+        date: {
+          pickerAppearance: 'monthOnly',
+        },
+      },
     },
     {
       name: 'endDate',
       type: 'date',
+      admin: {
+        date: {
+          pickerAppearance: 'monthOnly',
+        },
+      },
     },
     {
       name: 'isCurrent',
       type: 'checkbox',
       defaultValue: false,
-    },
-    {
-      name: 'order',
-      type: 'number',
-      admin: {
-        description: 'Display order (lower numbers appear first)',
-      },
     },
   ],
   timestamps: true,

--- a/src/components/home/EducationSection.tsx
+++ b/src/components/home/EducationSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ScrollReveal } from '@/components/motion/ScrollReveal'
+import { Timeline, type TimelineItemData } from '@/components/ui/Timeline'
 
 interface EducationSectionProps {
   education: Array<{
@@ -9,41 +9,27 @@ interface EducationSectionProps {
     degree: string
     startDate: string
     endDate?: string | null
-    description?: any
   }>
 }
 
-function formatDate(dateString: string | null | undefined) {
-  if (!dateString) return 'Present'
-  return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric' })
-}
-
 export function EducationSection({ education }: EducationSectionProps) {
-  if (!education || education.length === 0) return null
-
-  const firstEducation = education[0]
+  const timelineItems: TimelineItemData[] = education.map((edu) => ({
+    id: edu.id,
+    title: edu.degree,
+    subtitle: edu.institution,
+    startDate: edu.startDate,
+    endDate: edu.endDate,
+  }))
 
   return (
-    <section className="py-24 lg:py-32 pl-8 pr-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1] border-t border-[#333]">
-      <div className="max-w-6xl mx-auto">
-        <ScrollReveal delay={0.1}>
-          <div>
-            <span className="font-sans text-xs uppercase tracking-[0.3em] text-[#8b8680] mb-6 block">
-              Education
-            </span>
-            <h3 className="font-serif text-2xl lg:text-3xl mb-4">{firstEducation.degree}</h3>
-            <p className="font-sans text-lg text-[#c4a35a] mb-2">{firstEducation.institution}</p>
-            <p className="font-sans text-sm text-[#8b8680] mb-4">
-              {formatDate(firstEducation.startDate)} — {formatDate(firstEducation.endDate)}
-            </p>
-            {firstEducation.description && typeof firstEducation.description === 'string' && (
-              <p className="font-sans text-[#b8b4ab] leading-relaxed">
-                {firstEducation.description}
-              </p>
-            )}
-          </div>
-        </ScrollReveal>
-      </div>
-    </section>
+    <Timeline
+      items={timelineItems}
+      header={{
+        label: 'Education',
+        count: education.length,
+      }}
+      showTopBorder={true}
+      sectionBg="bg-[#1a1a1a]"
+    />
   )
 }

--- a/src/components/home/ExperienceSection.tsx
+++ b/src/components/home/ExperienceSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ScrollReveal } from '@/components/motion/ScrollReveal'
+import { Timeline, type TimelineItemData } from '@/components/ui/Timeline'
 
 interface ExperienceSectionProps {
   experiences: Array<{
@@ -8,43 +8,29 @@ interface ExperienceSectionProps {
     company: string
     role: string
     startDate: string
-    endDate?: string | null | undefined
-    isCurrent?: boolean | null | undefined
-    description?: any
+    endDate?: string | null
+    isCurrent?: boolean | null
   }>
 }
 
-function formatDate(dateString: string | null | undefined) {
-  if (!dateString) return 'Present'
-  return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric' })
-}
-
 export function ExperienceSection({ experiences }: ExperienceSectionProps) {
-  if (!experiences || experiences.length === 0) return null
-
-  const firstExperience = experiences[0]
+  const timelineItems: TimelineItemData[] = experiences.map((exp) => ({
+    id: exp.id,
+    title: exp.role,
+    subtitle: exp.company,
+    startDate: exp.startDate,
+    endDate: exp.isCurrent ? null : exp.endDate,
+  }))
 
   return (
-    <section className="py-24 lg:py-32 pl-8 pr-6 lg:px-12 bg-[#1a1a1a] text-[#f8f6f1]">
-      <div className="max-w-6xl mx-auto">
-        <ScrollReveal>
-          <div>
-            <span className="font-sans text-xs uppercase tracking-[0.3em] text-[#8b8680] mb-6 block">
-              Experience
-            </span>
-            <h3 className="font-serif text-2xl lg:text-3xl mb-4">{firstExperience.role}</h3>
-            <p className="font-sans text-lg text-[#c4a35a] mb-2">{firstExperience.company}</p>
-            <p className="font-sans text-sm text-[#8b8680] mb-4">
-              {formatDate(firstExperience.startDate)} — {formatDate(firstExperience.endDate)}
-            </p>
-            {firstExperience.description && typeof firstExperience.description === 'string' && (
-              <p className="font-sans text-[#b8b4ab] leading-relaxed text-pretty">
-                {firstExperience.description}
-              </p>
-            )}
-          </div>
-        </ScrollReveal>
-      </div>
-    </section>
+    <Timeline
+      items={timelineItems}
+      header={{
+        label: 'Experience',
+        count: experiences.length,
+      }}
+      showTopBorder={false}
+      sectionBg="bg-[#1a1a1a]"
+    />
   )
 }

--- a/src/components/ui/Timeline.tsx
+++ b/src/components/ui/Timeline.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { ScrollReveal } from '@/components/motion/ScrollReveal'
+
+export interface TimelineItemData {
+  id: number | string
+  title: string
+  subtitle: string
+  startDate: string
+  endDate?: string | null
+  description?: string
+}
+
+interface TimelineProps {
+  items: TimelineItemData[]
+  header?: {
+    label: string
+    count?: number
+  }
+  sectionBg?: string
+  showTopBorder?: boolean
+}
+
+function formatDate(dateString: string | null | undefined) {
+  if (!dateString) return 'Present'
+  return new Date(dateString).toLocaleDateString('en-US', { year: 'numeric' })
+}
+
+export function Timeline({
+  items,
+  header,
+  sectionBg = 'bg-[#1a1a1a]',
+  showTopBorder = false,
+}: TimelineProps) {
+  if (!items || items.length === 0) return null
+
+  return (
+    <section
+      className={`py-24 lg:py-32 pl-8 pr-6 lg:px-12 ${sectionBg} text-[#f8f6f1] ${showTopBorder ? 'border-t border-[#333]' : ''}`}
+    >
+      <div className="max-w-6xl mx-auto">
+        {header && (
+          <header className="flex items-baseline justify-between mb-16">
+            <h2 className="font-serif text-4xl lg:text-5xl tracking-tight">{header.label}</h2>
+            <span className="font-sans text-xs uppercase tracking-[0.2em] text-[#8b8680]">
+              {header.count} item{header.count !== 1 ? 's' : ''}
+            </span>
+          </header>
+        )}
+
+        <div className="relative">
+          <div className="absolute left-[19px] top-2 bottom-2 w-[1px] bg-[#333]" />
+
+          <div className="space-y-16">
+            {items.map((item, index) => (
+              <ScrollReveal key={item.id} delay={index * 0.1}>
+                <div className="relative pl-12">
+                  <div className="absolute left-[-5px] top-[7px] w-[3px] h-[3px] bg-[#8b8680] rounded-full" />
+
+                  <div className="mb-2">
+                    <span className="font-sans text-xs uppercase tracking-[0.2em] text-[#8b8680]">
+                      {formatDate(item.startDate)} — {formatDate(item.endDate)}
+                    </span>
+                  </div>
+
+                  <h3 className="font-serif text-xl lg:text-2xl mb-1">{item.title}</h3>
+
+                  <p className="font-sans text-base text-[#c4a35a] mb-3">{item.subtitle}</p>
+
+                  {item.description && (
+                    <p className="font-sans text-[#b8b4ab] leading-relaxed text-pretty">
+                      {item.description}
+                    </p>
+                  )}
+                </div>
+              </ScrollReveal>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/lib/getHomepageData.ts
+++ b/src/lib/getHomepageData.ts
@@ -15,17 +15,12 @@ export async function getHomepageData(payload: Payload) {
 
       payload.find({
         collection: 'experience',
-        where: {
-          or: [{ isCurrent: { equals: true } }, { isCurrent: { exists: false } }],
-        },
-        sort: 'order',
-        limit: 3,
+        sort: '-startDate',
       }),
 
       payload.find({
         collection: 'education',
-        sort: 'startDate',
-        limit: 2,
+        sort: '-startDate',
       }),
 
       payload.find({

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -219,10 +219,6 @@ export interface Experience {
   startDate: string;
   endDate?: string | null;
   isCurrent?: boolean | null;
-  /**
-   * Display order (lower numbers appear first)
-   */
-  order?: number | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -452,7 +448,6 @@ export interface ExperienceSelect<T extends boolean = true> {
   startDate?: T;
   endDate?: T;
   isCurrent?: T;
-  order?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
## Summary

- Create reusable `Timeline` component with left-aligned vertical line and dot markers
- Display all education and experience entries in chronological order (most recent first)
- Add section headers with item counts for clear visual distinction
- Update Experience collection: remove order field, add month-only date picker for consistency
- Remove data fetching limits and fix experience query filter to show all entries

## Changes

- New `src/components/ui/Timeline.tsx` - Reusable timeline component
- Refactored `EducationSection.tsx` and `ExperienceSection.tsx` to use Timeline
- Updated `Experience.ts` collection schema (removed order, added monthOnly date picker)
- Updated `getHomepageData.ts` to remove limits and fix sorting/filtering
- Auto-generated `payload-types.ts` updated