### PR TITLE
Remove order field from Technologies collection

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -91,7 +91,6 @@ async function seed() {
           role: 'Full-Stack Developer',
           startDate: '2023-01-01',
           isCurrent: true,
-          order: 1,
         },
       })
       console.log('✓ Experience created\n')

--- a/src/collections/Technologies.ts
+++ b/src/collections/Technologies.ts
@@ -4,7 +4,7 @@ export const Technologies: CollectionConfig = {
   slug: 'technologies',
   admin: {
     useAsTitle: 'name',
-    defaultColumns: ['name', 'category', 'order'],
+    defaultColumns: ['name', 'category'],
   },
   fields: [
     {
@@ -22,13 +22,6 @@ export const Technologies: CollectionConfig = {
         { label: 'Database', value: 'database' },
         { label: 'Tools', value: 'tools' },
       ],
-    },
-    {
-      name: 'order',
-      type: 'number',
-      admin: {
-        description: 'Display order (lower numbers appear first)',
-      },
     },
   ],
 }

--- a/src/lib/getHomepageData.ts
+++ b/src/lib/getHomepageData.ts
@@ -25,7 +25,7 @@ export async function getHomepageData(payload: Payload) {
 
       payload.find({
         collection: 'technologies',
-        sort: 'order',
+        sort: 'name',
       }),
 
       payload.find({

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -185,10 +185,6 @@ export interface Technology {
   id: number;
   name: string;
   category?: ('frontend' | 'backend' | 'database' | 'tools') | null;
-  /**
-   * Display order (lower numbers appear first)
-   */
-  order?: number | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -422,7 +418,6 @@ export interface MediaSelect<T extends boolean = true> {
 export interface TechnologiesSelect<T extends boolean = true> {
   name?: T;
   category?: T;
-  order?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
## Summary

- Remove order field from Technologies collection schema
- Update sorting to alphabetical by name
- Remove order from seed script

## Changes

- `Technologies.ts` - Remove order field and update admin columns
- `getHomepageData.ts` - Change sort from 'order' to 'name'
- `seed.ts` - Remove order field from experience creation
- `payload-types.ts` - Auto-generated types updated