### PR TITLE
Fix projects list admin view to display by title

### DIFF
--- a/src/collections/Projects.ts
+++ b/src/collections/Projects.ts
@@ -4,7 +4,7 @@ export const Projects: CollectionConfig = {
   slug: 'projects',
   admin: {
     useAsTitle: 'title',
-    defaultColumns: ['order'],
+    defaultColumns: ['title'],
     listSearchableFields: ['title', 'excerpt'],
   },
   fields: [


### PR DESCRIPTION
## Summary
- Changed projects collection admin view to display projects by title instead of order number
- Updated `defaultColumns` in Projects collection config from `['order']` to `['title']`

## Changes
- Modified `src/collections/Projects.ts` to improve admin panel usability