### PR TITLE
fix: show all technologies on homepage by removing display limit

### DIFF
--- a/src/collections/Technologies.ts
+++ b/src/collections/Technologies.ts
@@ -22,6 +22,7 @@ export const Technologies: CollectionConfig = {
         { label: 'Database', value: 'database' },
         { label: 'Tools', value: 'tools' },
       ],
+      required: true,
     },
   ],
 }

--- a/src/lib/getHomepageData.ts
+++ b/src/lib/getHomepageData.ts
@@ -26,6 +26,7 @@ export async function getHomepageData(payload: Payload) {
       payload.find({
         collection: 'technologies',
         sort: 'name',
+        limit: 100,
       }),
 
       payload.find({

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -184,7 +184,7 @@ export interface Media {
 export interface Technology {
   id: number;
   name: string;
-  category?: ('frontend' | 'backend' | 'database' | 'tools') | null;
+  category: 'frontend' | 'backend' | 'database' | 'tools';
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary

- Increased technologies query limit from default (10) to 100 in `getHomepageData.ts`
- Made `category` field required in Technologies collection to prevent unfiltered entries

## Issue

Technologies weren't appearing on the homepage beyond the first 10 entries. Payload's default `limit` is 10, which caused technologies alphabetically after the first 10 to be silently truncated.

## Changes

- `src/lib/getHomepageData.ts`: Added `limit: 100` to technologies query
- `src/collections/Technologies.ts`: Added `required: true` to category field
- `src/payload-types.ts`: Updated Technology type (auto-generated)

## Testing

Verified that TailwindCSS now appears in the frontend technologies section on homepage.