### PR TITLE
Remove order field from Labs collection

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -233,7 +233,6 @@ async function seed() {
       technologies: 'Rust',
       githubUrl: '',
       featured: true,
-      order: 1,
     },
     {
       name: 'Go API Server',
@@ -241,7 +240,6 @@ async function seed() {
       technologies: 'Go, PostgreSQL',
       githubUrl: '',
       featured: true,
-      order: 2,
     },
     {
       name: 'Weather Dashboard',
@@ -249,7 +247,6 @@ async function seed() {
       technologies: 'React, D3.js',
       githubUrl: '',
       featured: true,
-      order: 3,
     },
     {
       name: 'Portfolio v1',
@@ -257,7 +254,6 @@ async function seed() {
       technologies: 'Next.js, MDX',
       githubUrl: '',
       featured: true,
-      order: 4,
     },
     {
       name: 'Task Tracker',
@@ -265,7 +261,6 @@ async function seed() {
       technologies: 'Svelte, SQLite',
       githubUrl: '',
       featured: true,
-      order: 5,
     },
     {
       name: 'Color Palette Gen',
@@ -273,7 +268,6 @@ async function seed() {
       technologies: 'TypeScript, Canvas',
       githubUrl: '',
       featured: true,
-      order: 6,
     },
   ]
 

--- a/src/collections/Lab.ts
+++ b/src/collections/Lab.ts
@@ -4,7 +4,7 @@ export const Lab: CollectionConfig = {
   slug: 'lab',
   admin: {
     useAsTitle: 'name',
-    defaultColumns: ['name', 'featured', 'order'],
+    defaultColumns: ['name', 'featured'],
   },
   fields: [
     {
@@ -39,13 +39,6 @@ export const Lab: CollectionConfig = {
       name: 'featured',
       type: 'checkbox',
       defaultValue: true,
-    },
-    {
-      name: 'order',
-      type: 'number',
-      admin: {
-        description: 'Display order (lower numbers appear first)',
-      },
     },
   ],
   timestamps: true,

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -60,7 +60,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
       : null
 
   return (
-    <article className="group">
+    <article className="group hover:-translate-y-1 hover:shadow-lg transition-all duration-300 ease-out will-change-transform">
       <a href={project.liveUrl || '#'} target="_blank" rel="noopener noreferrer" className="block">
         <StaggerContainer className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8 items-start">
           <StaggerItem className="lg:col-span-7">

--- a/src/lib/getHomepageData.ts
+++ b/src/lib/getHomepageData.ts
@@ -34,7 +34,7 @@ export async function getHomepageData(payload: Payload) {
         where: {
           featured: { equals: true },
         },
-        sort: 'order',
+        sort: 'name',
         limit: 6,
       }),
 

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -270,10 +270,6 @@ export interface Lab {
    */
   githubUrl?: string | null;
   featured?: boolean | null;
-  /**
-   * Display order (lower numbers appear first)
-   */
-  order?: number | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -472,7 +468,6 @@ export interface LabSelect<T extends boolean = true> {
   technologies?: T;
   githubUrl?: T;
   featured?: T;
-  order?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
## Summary
- Removed the `order` field from the Labs collection schema
- Updated the homepage data fetching to sort labs alphabetically by `name` instead of `order`
- Removed references to `order` in the seed script
- Added hover lift animation to project cards for better interactivity

## Changes
- `src/collections/Lab.ts`: Removed `order` field from collection definition and admin columns
- `src/lib/getHomepageData.ts`: Changed sort from `'order'` to `'name'`
- `scripts/seed.ts`: Removed `order` property from all lab seed items
- `src/components/ui/ProjectCard.tsx`: Added hover lift animation with shadow for better affordance