### PR TITLE
Remove featured flag from Labs collection

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -232,42 +232,36 @@ async function seed() {
       description: 'File processing utility built to learn Rust',
       technologies: 'Rust',
       githubUrl: '',
-      featured: true,
     },
     {
       name: 'Go API Server',
       description: 'REST API with middleware and auth',
       technologies: 'Go, PostgreSQL',
       githubUrl: '',
-      featured: true,
     },
     {
       name: 'Weather Dashboard',
       description: 'Real-time data visualization',
       technologies: 'React, D3.js',
       githubUrl: '',
-      featured: true,
     },
     {
       name: 'Portfolio v1',
       description: 'Previous iteration of this site',
       technologies: 'Next.js, MDX',
       githubUrl: '',
-      featured: true,
     },
     {
       name: 'Task Tracker',
       description: 'Local-first productivity app',
       technologies: 'Svelte, SQLite',
       githubUrl: '',
-      featured: true,
     },
     {
       name: 'Color Palette Gen',
       description: 'Algorithmic color scheme generator',
       technologies: 'TypeScript, Canvas',
       githubUrl: '',
-      featured: true,
     },
   ]
 

--- a/src/collections/Lab.ts
+++ b/src/collections/Lab.ts
@@ -4,7 +4,7 @@ export const Lab: CollectionConfig = {
   slug: 'lab',
   admin: {
     useAsTitle: 'name',
-    defaultColumns: ['name', 'featured'],
+    defaultColumns: ['name'],
   },
   fields: [
     {
@@ -34,11 +34,6 @@ export const Lab: CollectionConfig = {
       admin: {
         description: 'Optional link to GitHub repository',
       },
-    },
-    {
-      name: 'featured',
-      type: 'checkbox',
-      defaultValue: true,
     },
   ],
   timestamps: true,

--- a/src/lib/getHomepageData.ts
+++ b/src/lib/getHomepageData.ts
@@ -31,11 +31,7 @@ export async function getHomepageData(payload: Payload) {
 
       payload.find({
         collection: 'lab',
-        where: {
-          featured: { equals: true },
-        },
         sort: 'name',
-        limit: 6,
       }),
 
       payload.findGlobal({ slug: 'contact' }).catch(() => null),

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -269,7 +269,6 @@ export interface Lab {
    * Optional link to GitHub repository
    */
   githubUrl?: string | null;
-  featured?: boolean | null;
   updatedAt: string;
   createdAt: string;
 }
@@ -467,7 +466,6 @@ export interface LabSelect<T extends boolean = true> {
   description?: T;
   technologies?: T;
   githubUrl?: T;
-  featured?: T;
   updatedAt?: T;
   createdAt?: T;
 }


### PR DESCRIPTION
## Summary
Removed the `featured` checkbox field from the Labs collection, simplifying the data model. All lab items are now displayed alphabetically on the homepage without filtering.

## Changes
- `src/collections/Lab.ts`: Removed `featured` field from collection definition and admin columns
- `src/lib/getHomepageData.ts`: Removed `where: { featured: { equals: true } }` filter and `limit: 6`
- `scripts/seed.ts`: Removed `featured` property from all lab seed items