### PR TITLE
fix: remove hover effects on project cards on mobile

### DIFF
--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -37,7 +37,7 @@ function ImageLift({
 }) {
   return (
     <div className={`relative overflow-hidden ${className} group`}>
-      <div className="h-full w-full transition-transform duration-400 group-hover:scale-102">
+      <div className="h-full w-full transition-transform duration-400 lg:group-hover:scale-102">
         {children}
       </div>
     </div>
@@ -60,7 +60,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
       : null
 
   return (
-    <article className="group hover:-translate-y-1 hover:shadow-lg transition-all duration-300 ease-out will-change-transform">
+    <article className="group lg:hover:-translate-y-1 lg:hover:shadow-lg max-lg:active:scale-[0.98] transition-all duration-300 ease-out">
       <a href={project.liveUrl || '#'} target="_blank" rel="noopener noreferrer" className="block">
         <StaggerContainer className="grid grid-cols-1 lg:grid-cols-12 gap-6 lg:gap-8 items-start">
           <StaggerItem className="lg:col-span-7">


### PR DESCRIPTION
## Summary
Removes hover-based transforms from project cards on mobile, as touch devices don't naturally support hover interactions.

## Changes
- Scoped hover effects (`-translate-y-1`, `shadow-lg`) to desktop only with `lg:` prefix
- Scoped image zoom effect (`group-hover:scale-102`) to desktop only
- Removed `will-change-transform` (unnecessary hint)
- Added mobile touch feedback with `max-lg:active:scale-[0.98]` for subtle press effect

## Problem
On mobile, hover effects triggered intermittently on tap or became sticky, creating:
- Shadow that appeared disconnected from content (stuck on text portion)
- Image zoom without meaningful user intent
- Confusing UX where hover state had no clear trigger

## Solution
Desktop retains existing hover lift + shadow + zoom effects. Mobile uses press-shrink effect for tactile feedback when tapping cards.